### PR TITLE
Use paginate setting in site config

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ $paginator := .Paginate (where .Data.Pages "Type" "post") .Site.Params.perPage }}
+{{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
 	<div class="uk-block uk-block-default">
 		<div class="uk-container uk-container-center">
 			<div class="uk-grid">


### PR DESCRIPTION
Instead of pageNum site param which may or may not have been set (I don't see it in the documentation, and site breaks without it).

`paginate` will always have a value -- and is a better choice when only one setting is needed.
